### PR TITLE
FEAT : Support API level 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     ext {
         setup = [compileSdk: 25,
                  buildTools: "25.0.3",
-                 minSdk    : 17,
+                 minSdk    : 16,
                  targetSdk : 25]
 
         versions = [supportLib: "25.3.1"]

--- a/library/src/main/java/com/matpag/clickdrawabletextview/CsDrawableSettings.java
+++ b/library/src/main/java/com/matpag/clickdrawabletextview/CsDrawableSettings.java
@@ -3,6 +3,7 @@ package com.matpag.clickdrawabletextview;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 /**
  * Global configuration to handle correctly some user specific choices
@@ -29,16 +30,22 @@ public class CsDrawableSettings {
      *                    be the proper choice in the most cases
      */
     public static void init(Context context, String packageName){
-        PackageManager pManager = context.getApplicationContext().getPackageManager();
-        try {
-            ApplicationInfo appInfo = pManager.getApplicationInfo(packageName, 0);
-            //read the Application android:supportsRtl xml properties (if present), default false
-            boolean rtlSupport = (appInfo.flags & ApplicationInfo.FLAG_SUPPORTS_RTL) != 0;
-            mSettings = new CsDrawableSettings(rtlSupport);
-        } catch (PackageManager.NameNotFoundException nfe){
-            throw new IllegalArgumentException("Unable to get info for the provided packageName, " +
-                    "are you sure is it correct? BuildConfig.APPLICATION_ID should be fine " +
-                    "for the most cases");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+            PackageManager pManager = context.getApplicationContext().getPackageManager();
+            try {
+                ApplicationInfo appInfo = pManager.getApplicationInfo(packageName, 0);
+                //read the Application android:supportsRtl xml properties (if present), default false
+                boolean rtlSupport = (appInfo.flags & ApplicationInfo.FLAG_SUPPORTS_RTL) != 0;
+                mSettings = new CsDrawableSettings(rtlSupport);
+            } catch (PackageManager.NameNotFoundException nfe){
+                throw new IllegalArgumentException("Unable to get info for the provided " +
+                        "packageName, are you sure is it correct? BuildConfig.APPLICATION_ID " +
+                        "should be fine in most cases");
+            }
+        } else {
+            //prior to API 17 RTL is not supported, so we create settings instance
+            //with default false support for RTL
+            mSettings = new CsDrawableSettings(false);
         }
     }
 

--- a/library/src/main/java/com/matpag/clickdrawabletextview/CsDrawableViewManager.java
+++ b/library/src/main/java/com/matpag/clickdrawabletextview/CsDrawableViewManager.java
@@ -1,10 +1,12 @@
 package com.matpag.clickdrawabletextview;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.MotionEvent;
@@ -174,8 +176,12 @@ final class CsDrawableViewManager implements ClickableDrawable {
      * @return true if in RTL, false otherwise
      */
     private boolean isLayoutRTL(){
-        return CsDrawableSettings.isRtlSupportEnabled() &&
-                mConfig.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return CsDrawableSettings.isRtlSupportEnabled() &&
+                    mConfig.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        } else {
+            return CsDrawableSettings.isRtlSupportEnabled();
+        }
     }
 
     /**
@@ -206,6 +212,7 @@ final class CsDrawableViewManager implements ClickableDrawable {
      * Add the compound drawables to the view, if the Locale of the user is in
      * RTL mode the drawables will be added in the proper position
      */
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     private void addCompoundDrawablesRelative(){
         view.setCompoundDrawablesRelative(
                 mStartDrawable != null ? mStartDrawable.getDrawableIfVisible() : null,


### PR DESCRIPTION
With this implementation the library will work in API 16 too, which based on Google stats [here](https://developer.android.com/about/dashboards/index.html#Platform) will cover 98.2% of devices.

RTL works only for API >= 17 while for API 16 will be disabled by default.

Close #2 